### PR TITLE
Use cross_fields instead of most_fields

### DIFF
--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -238,7 +238,7 @@ class ElasticClient:
                         'function_score',
                         query=query.Bool(should=[query.MultiMatch(
                             query=query_text,
-                            type='most_fields',
+                            type='cross_fields',
                             fields=['title^7', 'acronym^7', 'description^4', 'organization_name^4'],
                             operator="and")]),
                         functions=datasets_score_functions


### PR DESCRIPTION
Use [cross_fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-cross-fields) to match terms in multiple fields with operator and. In our case, all terms must be present in at least one field.
Previously, all terms should have matched in a unique field.

When computing scores locally on search indicator pairs, the score slightly improve compare to previous `most_fields`.