### PR TITLE
Limit fuzziness to 4 chars words minimum instead of default 3

### DIFF
--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -191,7 +191,7 @@ class ElasticClient:
                         query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['name^15', 'acronym^15', 'description^8'])]),
                         functions=organizations_score_functions
                     ),
-                query.Match(title={"query": query_text, 'fuzziness': 'AUTO'})
+                query.Match(title={"query": query_text, 'fuzziness': 'AUTO:4,6'})
             ])
         else:
             s = s.query(query.Q('function_score', query=query.MatchAll(), functions=organizations_score_functions))
@@ -248,7 +248,7 @@ class ElasticClient:
                             operator="and")]),
                         functions=datasets_score_functions
                     ),
-                    query.MultiMatch(query=query_text, type='most_fields', operator="and", fields=['title', 'organization_name'], fuzziness='AUTO')
+                    query.MultiMatch(query=query_text, type='most_fields', operator="and", fields=['title', 'organization_name'], fuzziness='AUTO:4,6')
                 ])
         else:
             s = s.query(query.Q('function_score', query=query.MatchAll(), functions=datasets_score_functions))
@@ -283,7 +283,7 @@ class ElasticClient:
                         query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['title^15', 'description^8', 'organization_name^8'])]),
                         functions=reuses_score_functions
                     ),
-                    query.MultiMatch(query=query_text, type='most_fields', fields=['title', 'organization_name'], fuzziness='AUTO')
+                    query.MultiMatch(query=query_text, type='most_fields', fields=['title', 'organization_name'], fuzziness='AUTO:4,6')
                 ])
         else:
             s = s.query(query.Q('function_score', query=query.MatchAll(), functions=reuses_score_functions))


### PR DESCRIPTION
Related to https://github.com/etalab/data.gouv.fr/issues/674.

See fuzziness options: https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness.

The new value makes sure that we don't apply fuzziness on 3-char words, ex on `ZNT` acronym, but only on 4-char words minimum.