### PR TITLE
Strip markdown description

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ kafka-python==2.0.2
 pydantic==1.9.0
 pytest==6.2.5
 pytest-flask==1.2.0
-markdown==3.3.6
+markdown==3.3.3
 beautifulsoup4==4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ kafka-python==2.0.2
 pydantic==1.9.0
 pytest==6.2.5
 pytest-flask==1.2.0
+markdown==3.3.6
+beautifulsoup4==4.10.0

--- a/tests/test_kafka_consumer.py
+++ b/tests/test_kafka_consumer.py
@@ -2,7 +2,7 @@ import datetime
 import json
 
 from udata_search_service.infrastructure.kafka_consumer import parse_message
-from udata_search_service.infrastructure.utils import get_concat_title_org, log2p
+from udata_search_service.infrastructure.utils import get_concat_title_org, log2p, mdstrip
 
 
 def test_parse_dataset_message():
@@ -52,9 +52,12 @@ def test_parse_dataset_message():
     assert index_name == 'dataset'
 
     # Make sure that these fields are loaded as is
-    for key in ['id', 'title', 'url', 'frequency', 'resources_count', 'description',
+    for key in ['id', 'title', 'url', 'frequency', 'resources_count',
                 'acronym', 'badges', 'tags', 'license', 'owner', 'schema']:
         assert data[key] == message['data'][key]
+
+    # Make sure that markdown fields are stripped
+    assert data["description"] == mdstrip(message['data']["description"])
 
     # Make sure that these fields are log2p-normalized
     for key in ['views', 'followers', 'reuses']:
@@ -112,8 +115,11 @@ def test_parse_reuse_message():
 
     # Make sure that these fields are loaded as is
     for key in ['id', 'title', 'url', 'datasets', 'featured',
-                'description', 'badges', 'tags', 'owner']:
+                'badges', 'tags', 'owner']:
         assert data[key] == message['data'][key]
+
+    # Make sure that markdown fields are stripped
+    assert data["description"] == mdstrip(message['data']["description"])
 
     # Make sure that these fields are log2p-normalized
     for key in ['views', 'followers']:
@@ -154,8 +160,11 @@ def test_parse_organization_message():
     assert index_name == 'organization'
 
     # Make sure that these fields are loaded as is
-    for key in ['id', 'name', 'acronym', 'description', 'url', 'badges', 'orga_sp', 'datasets', 'reuses']:
+    for key in ['id', 'name', 'acronym', 'url', 'badges', 'orga_sp', 'datasets', 'reuses']:
         assert data[key] == message['data'][key]
+
+    # Make sure that markdown fields are stripped
+    assert data["description"] == mdstrip(message['data']["description"])
 
     # Make sure that these fields are log2p-normalized
     assert data["followers"] == log2p(message['data']["followers"])

--- a/udata_search_service/infrastructure/kafka_consumer.py
+++ b/udata_search_service/infrastructure/kafka_consumer.py
@@ -8,7 +8,7 @@ from elasticsearch.exceptions import ConnectionError
 from kafka import KafkaConsumer
 
 from udata_search_service.domain.entities import Dataset, Organization, Reuse
-from udata_search_service.infrastructure.utils import get_concat_title_org, log2p
+from udata_search_service.infrastructure.utils import get_concat_title_org, log2p, mdstrip
 
 ELASTIC_HOST = os.environ.get('ELASTIC_HOST', 'localhost')
 ELASTIC_PORT = os.environ.get('ELASTIC_PORT', '9200')
@@ -59,6 +59,9 @@ def create_kafka_consumer():
 class DatasetConsumer(Dataset):
     @classmethod
     def load_from_dict(cls, data):
+        # Strip markdown
+        data["description"] = mdstrip(data["description"])
+
         organization = data["organization"]
         data["organization"] = organization.get('id') if organization else None
         data["orga_followers"] = organization.get('followers') if organization else None
@@ -82,6 +85,9 @@ class DatasetConsumer(Dataset):
 class ReuseConsumer(Reuse):
     @classmethod
     def load_from_dict(cls, data):
+        # Strip markdown
+        data["description"] = mdstrip(data["description"])
+
         organization = data["organization"]
         data["organization"] = organization.get('id') if organization else None
         data["orga_followers"] = organization.get('followers') if organization else None
@@ -97,6 +103,9 @@ class ReuseConsumer(Reuse):
 class OrganizationConsumer(Organization):
     @classmethod
     def load_from_dict(cls, data):
+        # Strip markdown
+        data["description"] = mdstrip(data["description"])
+
         data["followers"] = log2p(data.get("followers", 0))
         data["views"] = log2p(data.get("views", 0))
         return super().load_from_dict(data)

--- a/udata_search_service/infrastructure/utils.py
+++ b/udata_search_service/infrastructure/utils.py
@@ -3,6 +3,9 @@ import ssl
 from urllib.request import urlopen
 from tempfile import _TemporaryFileWrapper
 
+from bs4 import BeautifulSoup
+from markdown import markdown
+
 
 def download_catalog(url: str, fd: _TemporaryFileWrapper) -> None:
     ssl._create_default_https_context = ssl._create_unverified_context
@@ -24,9 +27,30 @@ def get_concat_title_org(title: str, acronym: str, organization_name: str) -> st
 
 
 def log2p(value):
-    # Add 2 to the field value and take the common logarithm.
-    # It makes sure that the result is > 0, needed for function score
-    # Using multiply boost mode
+    '''
+    Add 2 to the field value and take the common logarithm.
+    It makes sure that the result is > 0, needed for function score
+    Using multiply boost mode
+    '''
     if not value:
         value = 0
     return log(value + 2)
+
+
+EXCERPT_TOKEN = '<!--- --- -->'
+
+
+def mdstrip(value, length=None, end='…'):
+    '''
+    Truncate and strip tags from a markdown source
+
+    The markdown source is truncated at the excerpt if present and
+    smaller than the required length. Then, all html tags are stripped.
+    '''
+    if not value:
+        return ''
+    if EXCERPT_TOKEN in value:
+        value = value.split(EXCERPT_TOKEN, 1)[0]
+    rendered = markdown(value, wrap=False)
+    text = ''.join(BeautifulSoup(rendered, 'html.parser').findAll(text=True))
+    return text

--- a/udata_search_service/infrastructure/utils.py
+++ b/udata_search_service/infrastructure/utils.py
@@ -37,10 +37,7 @@ def log2p(value):
     return log(value + 2)
 
 
-EXCERPT_TOKEN = '<!--- --- -->'
-
-
-def mdstrip(value, length=None, end='…'):
+def mdstrip(value):
     '''
     Truncate and strip tags from a markdown source
 
@@ -49,8 +46,6 @@ def mdstrip(value, length=None, end='…'):
     '''
     if not value:
         return ''
-    if EXCERPT_TOKEN in value:
-        value = value.split(EXCERPT_TOKEN, 1)[0]
     rendered = markdown(value, wrap=False)
     text = ''.join(BeautifulSoup(rendered, 'html.parser').findAll(text=True))
     return text


### PR DESCRIPTION
Related to https://github.com/etalab/data.gouv.fr/issues/674.

Strip markdown from description field to keep text only for indexation.
Markdown stripping is applied when consuming kafka messages.

It prevents indexing url links for example.