### PR TITLE
Create indices with init-es only if nonexistent

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,28 +28,14 @@ def search_client(app):
 
 @pytest.fixture(autouse=True)
 def db(search_client):
-    suffix_name = '-' + datetime.now().strftime('%Y-%m-%d-%H-%M')
 
-    search_client.delete_index_with_alias('dataset')
-    SearchableDataset._index._name = 'dataset' + suffix_name
-    SearchableDataset.init()
-    Index('dataset' + suffix_name).put_alias(name='dataset')
-
-    search_client.delete_index_with_alias('reuse')
-    SearchableReuse._index._name = 'reuse' + suffix_name
-    SearchableReuse.init()
-    Index('reuse' + suffix_name).put_alias(name='reuse')
-
-    search_client.delete_index_with_alias('organization')
-    SearchableOrganization._index._name = 'organization' + suffix_name
-    SearchableOrganization.init()
-    Index('organization' + suffix_name).put_alias(name='organization')
+    search_client.clean_indices()
 
     yield
 
-    Index('dataset' + suffix_name).delete()
-    Index('reuse' + suffix_name).delete()
-    Index('organization' + suffix_name).delete()
+    SearchableDataset.delete_indices(search_client.es)
+    SearchableReuse.delete_indices(search_client.es)
+    SearchableOrganization.delete_indices(search_client.es)
 
 
 @pytest.fixture

--- a/udata_search_service/infrastructure/utils.py
+++ b/udata_search_service/infrastructure/utils.py
@@ -1,10 +1,13 @@
 from math import log
 import ssl
-from urllib.request import urlopen
+import sys
 from tempfile import _TemporaryFileWrapper
+from urllib.request import urlopen
 
 from bs4 import BeautifulSoup
 from markdown import markdown
+
+IS_TTY = sys.__stdin__.isatty()
 
 
 def download_catalog(url: str, fd: _TemporaryFileWrapper) -> None:

--- a/udata_search_service/presentation/commands.py
+++ b/udata_search_service/presentation/commands.py
@@ -9,14 +9,14 @@ from udata_search_service.infrastructure.migrate import set_alias as set_alias_f
 
 @inject
 def init_es_func(search_client: SearchClient = Provide[Container.search_client]) -> None:
-    click.echo("Setting up indices and aliases.")
+    click.echo("Setting up indices and aliases if they don't exist.")
     search_client.init_indices()
     click.echo("Done.")
 
 
 @inject
 def clean_es_func(search_client: SearchClient = Provide[Container.search_client]) -> None:
-    click.echo("Cleaning and creating indices and aliases.")
+    click.echo("Removing previous indices and intializing new ones.")
     search_client.clean_indices()
     click.echo("Done.")
 


### PR DESCRIPTION
`init-es` command used to create indices every time. Now it creates indices only if nonexistent.
This command can now be called on every deploy.

The initialization and cleaning logics have been moved to a new IndexDocument class.
Maybe we can iterate on this architecture for a better coherence with dependency injection and DDD.
I'm interested in improvement ideas @quaxsze.