### PR TITLE
Use views as orga func score instead of datasets count

### DIFF
--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -176,7 +176,7 @@ class ElasticClient:
         organizations_score_functions = [
             query.SF("field_value_factor", field="orga_sp", factor=8, modifier='sqrt', missing=1),
             query.SF("field_value_factor", field="followers", factor=4, modifier='sqrt', missing=1),
-            query.SF("field_value_factor", field="datasets", factor=1, modifier='sqrt', missing=1),
+            query.SF("field_value_factor", field="views", factor=1, modifier='sqrt', missing=1),
         ]
 
         if query_text:


### PR DESCRIPTION
I don't think the number of datasets is relevant in function score. I added the number of views instead.