### PR TITLE
Add configurable prefix for index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add configurable prefix for index [#26](https://github.com/opendatateam/udata-search-service/pull/26)
 
 ## 1.0.1 (2022-03-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Add configurable prefix for index [#26](https://github.com/opendatateam/udata-search-service/pull/26)
+- Add configurable prefix for index and prefix/suffix in kafka topics [#26](https://github.com/opendatateam/udata-search-service/pull/26)
 - Add cross fields in query search for reuses and organization [#27](https://github.com/opendatateam/udata-search-service/pull/27)
 - Improve Readme with deployment instructions [#28](https://github.com/opendatateam/udata-search-service/pull/28)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ udata-search-service init-es
 docker-compose run --entrypoint /bin/bash web -c 'udata-search-service init-es'
 ```
 
+This will create the following indices:
+- {UDATA_INSTANCE_NAME}-dataset-{DATETIME}
+- {UDATA_INSTANCE_NAME}-reuse-{DATETIME}
+- {UDATA_INSTANCE_NAME}-organization-{DATETIME}
+
 You can feed the elasticsearch by publishing messages to Kafka.
 Using [udata](https://github.com/opendatateam/udata), when you modify objects,
 indexation messages will be sent and will be consumed by the kafka consumer.
@@ -62,6 +67,8 @@ cd $WORKSPACE/udata/
 source ./venv/bin/activate
 udata search index
 ```
+
+Make sure to have the corresponding UDATA_INSTANCE_NAME specified in your udata settings.
 
 After a reindexation, you'll need to change the alias by using the following command:
 ```

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ docker-compose run --entrypoint /bin/bash web -c 'udata-search-service init-es'
 ```
 
 This will create the following indices:
-- {UDATA_INSTANCE_NAME}-dataset-{DATETIME}
-- {UDATA_INSTANCE_NAME}-reuse-{DATETIME}
-- {UDATA_INSTANCE_NAME}-organization-{DATETIME}
+- {UDATA_INSTANCE_NAME}-dataset-{yyyy}-{mm}-{dd}-{HH}-{MM}
+- {UDATA_INSTANCE_NAME}-reuse-{yyyy}-{mm}-{dd}-{HH}-{MM}
+- {UDATA_INSTANCE_NAME}-organization-{yyyy}-{mm}-{dd}-{HH}-{MM}
 
 You can feed the elasticsearch by publishing messages to Kafka.
 Using [udata](https://github.com/opendatateam/udata), when you modify objects,

--- a/tests/test_kafka_consumer.py
+++ b/tests/test_kafka_consumer.py
@@ -46,7 +46,7 @@ def test_parse_dataset_message():
         }
     }
     val_utf8 = json.dumps(message)
-    message_type, index_name, data = parse_message('dataset', val_utf8)
+    message_type, index_name, data = parse_message(val_utf8)
 
     assert message_type == 'index'
     assert index_name == 'dataset'
@@ -108,7 +108,7 @@ def test_parse_reuse_message():
         }
     }
     val_utf8 = json.dumps(message)
-    message_type, index_name, data = parse_message('reuse', val_utf8)
+    message_type, index_name, data = parse_message(val_utf8)
 
     assert message_type == 'index'
     assert index_name == 'reuse'
@@ -154,7 +154,7 @@ def test_parse_organization_message():
         }
     }
     val_utf8 = json.dumps(message)
-    message_type, index_name, data = parse_message('organization', val_utf8)
+    message_type, index_name, data = parse_message(val_utf8)
 
     assert message_type == 'index'
     assert index_name == 'organization'

--- a/tests/test_kafka_consumer.py
+++ b/tests/test_kafka_consumer.py
@@ -9,7 +9,7 @@ def test_parse_dataset_message():
     message = {
         'service': 'udata',
         'meta': {
-            'message_type': 'index',
+            'message_type': 'dataset.index',
             'index': 'dataset'
         },
         'data': {
@@ -83,7 +83,7 @@ def test_parse_reuse_message():
     message = {
         'service': 'udata',
         'meta': {
-            'message_type': 'index',
+            'message_type': 'reuse.index',
             'index': 'reuse'
         },        'data': {
             "id": "5cc2dfbe8b4c414c91ffc46d",
@@ -136,7 +136,7 @@ def test_parse_organization_message():
     message = {
         'service': 'udata',
         'meta': {
-            'message_type': 'index',
+            'message_type': 'organization.index',
             'index': 'organization'
         },        'data': {
             "id": "534fff75a3a7292c64a77de4",

--- a/udata_search_service/config.py
+++ b/udata_search_service/config.py
@@ -6,7 +6,7 @@ class Config:
 
     ELASTICSEARCH_URL = os.environ.get('ELASTICSEARCH_URL') or 'http://localhost:9200'
 
-    ELASTICSEARCH_INDEX_PREFIX = os.environ.get('ELASTICSEARCH_INDEX_PREFIX') or 'udata'
+    UDATA_INSTANCE_NAME = os.environ.get('UDATA_INSTANCE_NAME') or 'udata'
 
     SEARCH_SYNONYMS = [
         "AMD, administrateur ministériel des données, AMDAC",

--- a/udata_search_service/config.py
+++ b/udata_search_service/config.py
@@ -6,9 +6,7 @@ class Config:
 
     ELASTICSEARCH_URL = os.environ.get('ELASTICSEARCH_URL') or 'http://localhost:9200'
 
-    DATASET_CATALOG_URL = 'https://www.data.gouv.fr/fr/datasets/r/f868cca6-8da1-4369-a78d-47463f19a9a3'
-    ORG_CATALOG_URL = 'https://www.data.gouv.fr/fr/datasets/r/b7bbfedc-2448-4135-a6c7-104548d396e7'
-    REUSE_CATALOG_URL = 'https://www.data.gouv.fr/fr/datasets/r/970aafa0-3778-4d8b-b9d1-de937525e379'
+    ELASTICSEARCH_INDEX_PREFIX = os.environ.get('ELASTICSEARCH_INDEX_PREFIX') or 'udata'
 
     SEARCH_SYNONYMS = [
         "AMD, administrateur ministériel des données, AMDAC",

--- a/udata_search_service/infrastructure/kafka_consumer.py
+++ b/udata_search_service/infrastructure/kafka_consumer.py
@@ -52,7 +52,9 @@ def create_kafka_consumer():
         # on startup if Kafka Broker isn't ready yet
         api_version=tuple([int(value) for value in KAFKA_API_VERSION.split('.')])
         )
-    consumer.subscribe(TOPICS + [topic + '-reindex' for topic in TOPICS])
+
+    topics = [Config.UDATA_INSTANCE_NAME + '.' + topic for topic in TOPICS]
+    consumer.subscribe(topics)
     logging.info('Kafka Consumer created')
     return consumer
 
@@ -141,7 +143,7 @@ def consume_messages(consumer, es):
         val_utf8 = value.decode('utf-8').replace('NaN', 'null')
 
         key = message.key.decode('utf-8')
-        topic_short = message.topic.split('-')[0]
+        topic_short = message.topic.split('.')[1]  # Strip UDATA_INSTANCE_NAME out
 
         logging.debug(f'Message recieved with key: {key} and value: {value}')
 

--- a/udata_search_service/infrastructure/kafka_consumer.py
+++ b/udata_search_service/infrastructure/kafka_consumer.py
@@ -147,7 +147,7 @@ def consume_messages(consumer, es):
 
         try:
             message_type, index_name, data = parse_message(topic_short, val_utf8)
-            index_name = Config.ELASTICSEARCH_INDEX_PREFIX + '-' + index_name
+            index_name = Config.UDATA_INSTANCE_NAME + '-' + index_name
 
             if message_type in [KafkaMessageType.INDEX.value,
                                 KafkaMessageType.REINDEX.value]:

--- a/udata_search_service/infrastructure/kafka_consumer.py
+++ b/udata_search_service/infrastructure/kafka_consumer.py
@@ -53,7 +53,7 @@ def create_kafka_consumer():
         api_version=tuple([int(value) for value in KAFKA_API_VERSION.split('.')])
         )
 
-    topics = [Config.UDATA_INSTANCE_NAME + '.' + topic for topic in TOPICS]
+    topics = [f'{Config.UDATA_INSTANCE_NAME}.{topic}' for topic in TOPICS]
     consumer.subscribe(topics)
     logging.info('Kafka Consumer created')
     return consumer
@@ -143,13 +143,13 @@ def consume_messages(consumer, es):
         val_utf8 = value.decode('utf-8').replace('NaN', 'null')
 
         key = message.key.decode('utf-8')
-        topic_short = message.topic.split('.')[1]  # Strip UDATA_INSTANCE_NAME out
+        topic_short = '.'.join(message.topic.split('.')[1:])  # Strip UDATA_INSTANCE_NAME out
 
         logging.debug(f'Message recieved with key: {key} and value: {value}')
 
         try:
             message_type, index_name, data = parse_message(topic_short, val_utf8)
-            index_name = Config.UDATA_INSTANCE_NAME + '-' + index_name
+            index_name = f'{Config.UDATA_INSTANCE_NAME}-{index_name}'
 
             if message_type in [KafkaMessageType.INDEX.value,
                                 KafkaMessageType.REINDEX.value]:

--- a/udata_search_service/infrastructure/migrate.py
+++ b/udata_search_service/infrastructure/migrate.py
@@ -28,11 +28,12 @@ def set_alias(index_suffix_name: str, indices: List[str] = None, delete: bool = 
     es = Elasticsearch([{'host': ELASTIC_HOST, 'port': ELASTIC_PORT}])
 
     indices = indices or ALL_INDICES
-    for index in indices:
-        if index not in ALL_INDICES:
-            logging.error('Unknown index alias %s', index)
-            sys.exit(-1)
 
+    if unknown_indices := [x for x in indices if x not in ALL_INDICES]:
+        logging.error('Unknown indices: %s', ', '.join(unknown_indices))
+        sys.exit(-1)
+
+    for index in indices:
         index_alias = Config.ELASTICSEARCH_INDEX_PREFIX + '-' + index
         pattern = index_alias + '-*'
         index_name = index_alias + '-' + index_suffix_name

--- a/udata_search_service/infrastructure/migrate.py
+++ b/udata_search_service/infrastructure/migrate.py
@@ -28,12 +28,11 @@ def set_alias(index_suffix_name: str, indices: List[str] = None, delete: bool = 
     es = Elasticsearch([{'host': ELASTIC_HOST, 'port': ELASTIC_PORT}])
 
     indices = indices or ALL_INDICES
-
-    if unknown_indices := [x for x in indices if x not in ALL_INDICES]:
-        logging.error('Unknown indices: %s', ', '.join(unknown_indices))
-        sys.exit(-1)
-
     for index in indices:
+        if index not in ALL_INDICES:
+            logging.error('Unknown index alias %s', index)
+            sys.exit(-1)
+
         index_alias = Config.UDATA_INSTANCE_NAME + '-' + index
         pattern = index_alias + '-*'
         index_name = index_alias + '-' + index_suffix_name

--- a/udata_search_service/infrastructure/migrate.py
+++ b/udata_search_service/infrastructure/migrate.py
@@ -4,6 +4,7 @@ import sys
 from typing import List
 
 from elasticsearch import Elasticsearch
+from udata_search_service.config import Config
 
 ELASTIC_HOST = os.environ.get('ELASTIC_HOST', 'localhost')
 ELASTIC_PORT = os.environ.get('ELASTIC_PORT', '9200')
@@ -27,11 +28,12 @@ def set_alias(index_suffix_name: str, indices: List[str] = None, delete: bool = 
     es = Elasticsearch([{'host': ELASTIC_HOST, 'port': ELASTIC_PORT}])
 
     indices = indices or ALL_INDICES
-    for index_alias in indices:
-        if index_alias not in ALL_INDICES:
-            logging.error('Unknown index alias %s', index_alias)
+    for index in indices:
+        if index not in ALL_INDICES:
+            logging.error('Unknown index alias %s', index)
             sys.exit(-1)
 
+        index_alias = Config.ELASTICSEARCH_INDEX_PREFIX + '-' + index
         pattern = index_alias + '-*'
         index_name = index_alias + '-' + index_suffix_name
         logging.info('Creating alias "%s" on index "%s"', index_alias, index_name)

--- a/udata_search_service/infrastructure/migrate.py
+++ b/udata_search_service/infrastructure/migrate.py
@@ -34,7 +34,7 @@ def set_alias(index_suffix_name: str, indices: List[str] = None, delete: bool = 
         sys.exit(-1)
 
     for index in indices:
-        index_alias = Config.ELASTICSEARCH_INDEX_PREFIX + '-' + index
+        index_alias = Config.UDATA_INSTANCE_NAME + '-' + index
         pattern = index_alias + '-*'
         index_name = index_alias + '-' + index_suffix_name
         logging.info('Creating alias "%s" on index "%s"', index_alias, index_name)

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -5,7 +5,7 @@ from typing import Tuple, Optional, List
 
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import NotFoundError
-from elasticsearch_dsl import Index, Date, Document, Float, Integer, Keyword, Text, tokenizer, token_filter, analyzer, query
+from elasticsearch_dsl import Date, Document, Float, Integer, Keyword, Text, tokenizer, token_filter, analyzer, query
 from elasticsearch_dsl.connections import connections
 from udata_search_service.domain.entities import Dataset, Organization, Reuse
 from udata_search_service.config import Config
@@ -71,7 +71,7 @@ class SearchableOrganization(IndexDocument):
     badges = Keyword(multi=True)
 
     class Index:
-        name = 'organization'
+        name = Config.ELASTICSEARCH_INDEX_PREFIX + '-organization'
 
 
 class SearchableReuse(IndexDocument):
@@ -93,7 +93,7 @@ class SearchableReuse(IndexDocument):
     owner = Keyword()
 
     class Index:
-        name = 'reuse'
+        name = Config.ELASTICSEARCH_INDEX_PREFIX + '-reuse'
 
 
 class SearchableDataset(IndexDocument):
@@ -125,7 +125,7 @@ class SearchableDataset(IndexDocument):
     schema = Keyword(multi=True)
 
     class Index:
-        name = 'dataset'
+        name = Config.ELASTICSEARCH_INDEX_PREFIX + '-dataset'
 
 
 class ElasticClient:

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -71,7 +71,7 @@ class SearchableOrganization(IndexDocument):
     badges = Keyword(multi=True)
 
     class Index:
-        name = Config.ELASTICSEARCH_INDEX_PREFIX + '-organization'
+        name = Config.UDATA_INSTANCE_NAME + '-organization'
 
 
 class SearchableReuse(IndexDocument):
@@ -93,7 +93,7 @@ class SearchableReuse(IndexDocument):
     owner = Keyword()
 
     class Index:
-        name = Config.ELASTICSEARCH_INDEX_PREFIX + '-reuse'
+        name = Config.UDATA_INSTANCE_NAME + '-reuse'
 
 
 class SearchableDataset(IndexDocument):
@@ -125,7 +125,7 @@ class SearchableDataset(IndexDocument):
     schema = Keyword(multi=True)
 
     class Index:
-        name = Config.ELASTICSEARCH_INDEX_PREFIX + '-dataset'
+        name = Config.UDATA_INSTANCE_NAME + '-dataset'
 
 
 class ElasticClient:

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -71,7 +71,7 @@ class SearchableOrganization(IndexDocument):
     badges = Keyword(multi=True)
 
     class Index:
-        name = Config.UDATA_INSTANCE_NAME + '-organization'
+        name = f'{Config.UDATA_INSTANCE_NAME}-organization'
 
 
 class SearchableReuse(IndexDocument):
@@ -93,7 +93,7 @@ class SearchableReuse(IndexDocument):
     owner = Keyword()
 
     class Index:
-        name = Config.UDATA_INSTANCE_NAME + '-reuse'
+        name = f'{Config.UDATA_INSTANCE_NAME}-reuse'
 
 
 class SearchableDataset(IndexDocument):
@@ -125,7 +125,7 @@ class SearchableDataset(IndexDocument):
     schema = Keyword(multi=True)
 
     class Index:
-        name = Config.UDATA_INSTANCE_NAME + '-dataset'
+        name = f'{Config.UDATA_INSTANCE_NAME}-dataset'
 
 
 class ElasticClient:


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/831.

With this proposal, we can add an ENV var `ELASTICSEARCH_INDEX_PREFIX` in our configuration to use a prefix to index, having an index `udata-dataset-2022-04-22-17-55` with alias `udata-dataset` for example.

We still need to think of a smooth deployment solution in dev and prod with this alternative.

- [x] Document index and alias name for more visiblity.

Migration strategy:
- keep udata-search-service web app and kafka-consumer running
- upgrade udata-search-service
- run `udata-search-service init-es` (with new templates and indices pattern)
- restart kafka-consumer
- udata index
- restart web app
- wait
- clean legacy templates and indices (using REST API calls)