### PR TITLE
Improve index deletion pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Externalise Kafka consumer to udata_event_service package. Replace `data` key of messages with `value` [#30](https://github.com/opendatateam/udata-search-service/pull/30)
-- Improve loggings [#31](https://github.com/opendatateam/udata-search-service/pull/31)
+- Improve loggings [#31](https://github.com/opendatateam/udata-search-service/pull/31) [#32](https://github.com/opendatateam/udata-search-service/pull/32)
 
 ## 1.0.2 (2022-06-09)
 

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -55,7 +55,7 @@ class IndexDocument(Document):
     @classmethod
     def delete_indices(cls, es_client: Elasticsearch) -> None:
         alias = cls._index._name
-        pattern = alias + '-*'
+        pattern = alias + '*'
         logging.info(f'Deleting indices with pattern {pattern}')
         es_client.indices.delete(index=pattern)
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/842

Use `dev-dataset*` instead of `dev-dataset-*` as pattern for index deletion.