### PR TITLE
Use redpanda container instead of kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Use redpanda instead of Kafka [#34](https://github.com/opendatateam/udata-search-service/pull/34)
 
 ## 1.0.3 (2022-07-11)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,31 @@
 version: "3.8"
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.0
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
   broker:
-    image: confluentinc/cp-server:7.0.0
-    hostname: broker
+    # NB: do not use v22 since redpanda.auto_create_topics_enabled is not supported
+    # cf https://cwiki.apache.org/confluence/display/KAFKA/KIP-487%3A+Client-side+Automatic+Topic+Creation+on+Producer
+    # also for more thoughts about this option even in Kafka
+    image: docker.vectorized.io/vectorized/redpanda:v21.11.19
     container_name: broker
-    depends_on:
-      - zookeeper
+    command:
+      - redpanda start
+      - --smp 1
+      - --reserve 0M
+      - --overprovisioned
+      - --node-id 0
+      - --set redpanda.auto_create_topics_enabled=true
+      - --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
+      - --pandaproxy-addr 0.0.0.0:8082
+      - --advertise-pandaproxy-addr localhost:8082
     ports:
-      - "9092:9092"
-      - "9101:9101"
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9101
-      KAFKA_JMX_HOSTNAME: localhost
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      CONFLUENT_METRICS_ENABLE: 'true'
-      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
-      KAFKA_ADVERTISED_HOST_NAME: 'broker'
+      - 8081:8081
+      - 8082:8082
+      - 9092:9092
+      - 29092:29092
+    healthcheck:
+      test: curl -f localhost:9644/v1/status/ready
+      interval: 1s
+      start_period: 30s
 
   search:
     image: udata/elasticsearch:7.16.2
@@ -76,6 +64,25 @@ services:
       KAFKA_PORT: 29092
       KAFKA_API_VERSION: 2.5.0
       CONSUMER_LOGGING_LEVEL: 20
+
+  console:
+    image: docker.redpanda.com/vectorized/console
+    restart: on-failure
+    entrypoint: /bin/sh
+    command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"
+    environment:
+      CONFIG_FILEPATH: /tmp/config.yml
+      CONSOLE_CONFIG_FILE: |
+        kafka:
+          brokers: ["broker:29092"]
+          schemaRegistry:
+            enabled: true
+            urls: ["http://broker:8081"]
+    ports:
+      - "8080:8080"
+    depends_on:
+      broker:
+        condition: service_healthy
 
 volumes:
   es_data_prod:


### PR DESCRIPTION
Following https://github.com/etalab/data.gouv.fr/issues/908, using redpanda instead of Kafka for a lightweight solution.

Using redpanda instead of Kafka is transparent, no application change was needed.
Local reindexation of datasets, reuses and orgas takes roughly the same time (17min).