### PR TITLE
Upgrade flask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Upgrade Flask to 2.2.5 [#44](https://github.com/opendatateam/udata-search-service/pull/44)
 
 ## 2.0.2 (2023-09-01)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "factory-boy==3.2.1",
     "Faker==11.3.0",
     "flake8==4.0.1",
-    "Flask==3.0.0",
+    "Flask==2.2.5",
     "flit==3.6.0",
     "gunicorn==20.1.0",
     "pydantic==1.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "factory-boy==3.2.1",
     "Faker==11.3.0",
     "flake8==4.0.1",
-    "Flask==2.1.1",
+    "Flask==3.0.0",
     "flit==3.6.0",
     "gunicorn==20.1.0",
     "pydantic==1.9.0",


### PR DESCRIPTION
We currently have a version conflict with Werkzeug due to version not pinned in Flask https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls.

Upgrade Flask to 2.2.5, last working version with python 3.7.

When upgrading to python 3.11, we can then upgrade Flask to latest.