### PR TITLE
upgrade elasticsearch to native 7.17.28

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,4 @@
-version: "3.8"
 services:
-
   search_test:
     image: elasticsearch:7.17.28
     container_name: es01_test
@@ -8,6 +6,8 @@ services:
       - node.name=es01
       - cluster.name=es-docker-cluster
       - cluster.initial_master_nodes=es01
+      # try this if you run into error 137
+      # - ES_JAVA_OPTS=-Xms750m -Xmx750m
     tmpfs: /usr/share/elasticsearch/data
     expose:
       - "9200"
@@ -15,6 +15,8 @@ services:
       - "9201:9200"
     command: >
       bash -c "
-        elasticsearch-plugin install --batch analysis-icu &&
+        if ! elasticsearch-plugin list | grep -q analysis-icu; then
+          elasticsearch-plugin install --batch analysis-icu
+        fi &&
         /usr/local/bin/docker-entrypoint.sh eswrapper
       "

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
 
   search_test:
-    image: udata/elasticsearch:7.16.2
+    image: elasticsearch:7.17.28
     container_name: es01_test
     environment:
       - node.name=es01
@@ -13,3 +13,8 @@ services:
       - "9200"
     ports:
       - "9201:9200"
+    command: >
+      bash -c "
+        elasticsearch-plugin install --batch analysis-icu &&
+        /usr/local/bin/docker-entrypoint.sh eswrapper
+      "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   search:
     image: elasticsearch:7.17.28
@@ -7,6 +6,8 @@ services:
       - node.name=es01
       - cluster.name=es-docker-cluster
       - cluster.initial_master_nodes=es01
+      # try this if you run into error 137
+      # - ES_JAVA_OPTS=-Xms750m -Xmx750m
     volumes:
       - es_data_prod:/usr/share/elasticsearch/data
     expose:
@@ -15,7 +16,9 @@ services:
       - "9200:9200"
     command: >
       bash -c "
-        elasticsearch-plugin install --batch analysis-icu &&
+        if ! elasticsearch-plugin list | grep -q analysis-icu; then
+          elasticsearch-plugin install --batch analysis-icu
+        fi &&
         /usr/local/bin/docker-entrypoint.sh eswrapper
       "
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,16 +19,16 @@ services:
         /usr/local/bin/docker-entrypoint.sh eswrapper
       "
 
-  # web:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfiles/Dockerfile.app
-  #   expose:
-  #     - "5000"
-  #   ports:
-  #     - "5000:5000"
-  #   environment:
-  #     ELASTICSEARCH_URL: search:9200
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfiles/Dockerfile.app
+    expose:
+      - "5000"
+    ports:
+      - "5000:5000"
+    environment:
+      ELASTICSEARCH_URL: search:9200
 
 volumes:
   es_data_prod:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   search:
-    image: udata/elasticsearch:7.16.2
+    image: elasticsearch:7.17.28
     container_name: es01
     environment:
       - node.name=es01
@@ -13,17 +13,22 @@ services:
       - "9200"
     ports:
       - "9200:9200"
+    command: >
+      bash -c "
+        elasticsearch-plugin install --batch analysis-icu &&
+        /usr/local/bin/docker-entrypoint.sh eswrapper
+      "
 
-  web:
-    build:
-      context: .
-      dockerfile: Dockerfiles/Dockerfile.app
-    expose:
-      - "5000"
-    ports:
-      - "5000:5000"
-    environment:
-      ELASTICSEARCH_URL: search:9200
+  # web:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfiles/Dockerfile.app
+  #   expose:
+  #     - "5000"
+  #   ports:
+  #     - "5000:5000"
+  #   environment:
+  #     ELASTICSEARCH_URL: search:9200
 
 volumes:
   es_data_prod:


### PR DESCRIPTION
I had the following error on MacOS when launching elasticsearch in docker. Reproduced with native ES image 7.16.2, seems like a problem with this version nowadays (it has previously worked on my Mac). I couldn't find any JVM hack to work around the issue.

The issue is fixed in the latest 7.x. This PR upgrades to 7.17.28 and installs `analysis-icu` in the compose file instead of relying on a custom image.

```
es01  | 2025-06-23 13:35:14,861 main ERROR Could not reconfigure JMX java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
es01  | 	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81)
es01  | 	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:113)
es01  | 	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:167)
es01  | 	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
es01  | 	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
es01  | 	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
es01  | 	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
es01  | 	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280)
es01  | 	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199)
es01  | 	at java.management/java.lang.management.ManagementFactory.lambda$getPlatformMBeanServer$0(ManagementFactory.java:488)
es01  | 	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
es01  | 	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
es01  | 	at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1779)
es01  | 	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
es01  | 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
es01  | 	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
es01  | 	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
es01  | 	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
es01  | 	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
es01  | 	at java.management/java.lang.management.ManagementFactory.getPlatformMBeanServer(ManagementFactory.java:489)
es01  | 	at org.apache.logging.log4j.core.jmx.Server.reregisterMBeansAfterReconfigure(Server.java:140)
es01  | 	at org.apache.logging.log4j.core.LoggerContext.setConfiguration(LoggerContext.java:637)
es01  | 	at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:302)
es01  | 	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:209)
es01  | 	at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:243)
es01  | 	at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:219)
es01  | 	at org.elasticsearch.common.logging.LogConfigurator.configureStatusLogger(LogConfigurator.java:251)
es01  | 	at org.elasticsearch.common.logging.LogConfigurator.configureWithoutConfig(LogConfigurator.java:95)
es01  | 	at org.elasticsearch.cli.CommandLoggingConfigurator.configureLoggingWithoutConfig(CommandLoggingConfigurator.java:29)
es01  | 	at org.elasticsearch.cli.Command.main(Command.java:74)
es01  | 	at org.elasticsearch.plugins.cli.PluginCli.main(PluginCli.java:36)
```