### PR TITLE
Add resources ids and titles in search fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add object id in search fields [#55](https://github.com/opendatateam/udata-search-service/pull/55)
 
 ## 2.2.2 (2025-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add object id in search fields [#55](https://github.com/opendatateam/udata-search-service/pull/55)
+- Add resources ids and titles in search fields [#56](https://github.com/opendatateam/udata-search-service/pull/56)
 
 ## 2.2.2 (2025-03-14)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,6 +19,10 @@ def test_api_dataset_index_unindex(app, client, faker):
         'reuses': faker.random_int(),
         'featured': faker.random_int(min=0, max=1),
         'resources_count': faker.random_int(min=1, max=15),
+        'resources': [
+            {"id": faker.md5(), "title": faker.word()}
+            for _ in range(5)
+        ],
         'organization': {
             'id': faker.md5(),
             'name': faker.company(),
@@ -106,6 +110,10 @@ def test_api_dataset_index_on_another_index(app, client, search_client, faker):
         'reuses': faker.random_int(),
         'featured': faker.random_int(min=0, max=1),
         'resources_count': faker.random_int(min=1, max=15),
+        'resources': [
+            {"id": faker.md5(), "title": faker.word()}
+            for _ in range(5)
+        ],
         'organization': {
             'id': faker.md5(),
             'name': faker.company(),

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -23,6 +23,10 @@ def test_parse_dataset_obj():
         'reuses': 45,
         'featured': 0,
         'resources_count': 10,
+        'resources': [
+            {"id": "5ffa8553-0e8f-4622-add9-5c0b593ca1f8", "title": "Valeurs foncières 2024"},
+            {"id": "bc213c7c-c4d4-4385-bf1f-719573d39e90", "title": "Valeurs foncières 2023"},
+        ],
         'organization': {
             'id': '534fff8ea3a7292c64a77f02',
             'name': 'Ministère de l\'économie, des finances et de la relance',
@@ -69,6 +73,8 @@ def test_parse_dataset_obj():
     assert document['organization_name'] == obj['organization']['name']
     assert document['organization_badges'] == obj['organization']['badges']
     assert document['orga_followers'] == log2p(401)
+    assert document['resources_ids'] == [res["id"] for res in obj["resources"]]
+    assert document['resources_titles'] == [res["title"] for res in obj["resources"]]
 
 
 def test_parse_reuse_obj():

--- a/tests/test_search_client.py
+++ b/tests/test_search_client.py
@@ -441,3 +441,20 @@ def test_search_dataset_by_id(app, client, search_client, faker):
 
     results_number, res = search_client.query_datasets(str(dataset.id), 0, 20, {})
     assert results_number == 1
+
+
+def test_search_dataset_by_resource_title_and_id(app, client, search_client, faker):
+    dataset = DatasetFactory()
+    search_client.index_dataset(dataset)
+
+    for i in range(4):
+        search_client.index_dataset(DatasetFactory())
+
+    # Without this, ElasticSearch does not seem to have the time to index.
+    time.sleep(2)
+
+    results_number, res = search_client.query_datasets(str(dataset.resources_ids[0]), 0, 20, {})
+    assert results_number == 1
+
+    results_number, res = search_client.query_datasets(str(dataset.resources_titles[0]), 0, 20, {})
+    assert results_number == 1

--- a/tests/test_search_client.py
+++ b/tests/test_search_client.py
@@ -430,3 +430,14 @@ def test_search_dataset_with_synonym(app, client, search_client, faker):
 
     results_number, res = search_client.query_datasets('recensement population', 0, 20, {})
     assert results_number == 1
+
+
+def test_search_dataset_by_id(app, client, search_client, faker):
+    dataset = DatasetFactory()
+    search_client.index_dataset(dataset)
+
+    # Without this, ElasticSearch does not seem to have the time to index.
+    time.sleep(2)
+
+    results_number, res = search_client.query_datasets(str(dataset.id), 0, 20, {})
+    assert results_number == 1

--- a/udata_search_service/domain/entities.py
+++ b/udata_search_service/domain/entities.py
@@ -65,6 +65,8 @@ class Dataset(EntityBase):
     geozones: List[str] = None
     schema: List[str] = None
     topics: List[str] = None
+    resources_ids: List[str] = None
+    resources_titles: List[str] = None
 
     orga_sp: int = None
     orga_followers: int = None

--- a/udata_search_service/domain/factories.py
+++ b/udata_search_service/domain/factories.py
@@ -22,8 +22,8 @@ class DatasetFactory(factory.Factory):
     reuses = factory.Faker('random_int')
     featured = factory.Faker('random_int')
     resources_count = factory.Faker('random_int', min=1, max=15)
-    resources_ids = [factory.Faker('md5') for _ in range(5)]
-    resources_titles = [factory.Faker('sentence') for _ in range(5)]
+    resources_ids = factory.List([factory.Faker('md5') for _ in range(5)])
+    resources_titles = factory.List([factory.Faker('sentence') for _ in range(5)])
     organization = factory.Faker('md5')
     organization_name = factory.Faker('company')
     organization_badges = []

--- a/udata_search_service/domain/factories.py
+++ b/udata_search_service/domain/factories.py
@@ -22,6 +22,8 @@ class DatasetFactory(factory.Factory):
     reuses = factory.Faker('random_int')
     featured = factory.Faker('random_int')
     resources_count = factory.Faker('random_int', min=1, max=15)
+    resources_ids = [factory.Faker('md5') for _ in range(5)]
+    resources_titles = [factory.Faker('sentence') for _ in range(5)]
     organization = factory.Faker('md5')
     organization_name = factory.Faker('company')
     organization_badges = []

--- a/udata_search_service/infrastructure/consumers.py
+++ b/udata_search_service/infrastructure/consumers.py
@@ -24,6 +24,11 @@ class DatasetConsumer(Dataset):
         data["organization_name"] = organization.get('name') if organization else None
         data["organization_badges"] = organization.get('badges') if organization else None
 
+        resources = data["resources"]
+        data["resources_ids"] = [res.get("id") for res in resources]
+        data["resources_titles"] = [res.get("title") for res in resources]
+        del data["resources"]
+
         data["concat_title_org"] = get_concat_title_org(data["title"], data['acronym'], data['organization_name'])
         data["geozones"] = [zone.get("id") for zone in data.get("geozones", [])]
 

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -219,7 +219,7 @@ class ElasticClient:
             search = search.query('bool', should=[
                     query.Q(
                         'function_score',
-                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['name^15', 'acronym^15', 'description^8'])]),
+                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['id^15', 'name^15', 'acronym^15', 'description^8'])]),
                         functions=organizations_score_functions
                     ),
                     query.Q(
@@ -227,7 +227,7 @@ class ElasticClient:
                         query=query.Bool(should=[query.MultiMatch(
                             query=query_text,
                             type='cross_fields',
-                            fields=['name^7', 'acronym^7', 'description^4'],
+                            fields=['id^15', 'name^7', 'acronym^7', 'description^4'],
                             operator="and")]),
                         functions=organizations_score_functions
                     ),
@@ -282,7 +282,7 @@ class ElasticClient:
                 should=[
                     query.Q(
                         'function_score',
-                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['title^15', 'acronym^15', 'description^8', 'organization_name^8'])]),
+                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['id^15', 'title^15', 'acronym^15', 'description^8', 'organization_name^8'])]),
                         functions=datasets_score_functions
                     ),
                     query.Q(
@@ -295,7 +295,7 @@ class ElasticClient:
                         query=query.Bool(should=[query.MultiMatch(
                             query=query_text,
                             type='cross_fields',
-                            fields=['title^7', 'acronym^7', 'description^4', 'organization_name^4'],
+                            fields=['id^7', 'title^7', 'acronym^7', 'description^4', 'organization_name^4'],
                             operator="and")]),
                         functions=datasets_score_functions
                     ),
@@ -336,7 +336,7 @@ class ElasticClient:
             search = search.query('bool', should=[
                     query.Q(
                         'function_score',
-                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['title^15', 'description^8', 'organization_name^8'])]),
+                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['id^15', 'title^15', 'description^8', 'organization_name^8'])]),
                         functions=reuses_score_functions
                     ),
                     query.Q(
@@ -344,7 +344,7 @@ class ElasticClient:
                         query=query.Bool(should=[query.MultiMatch(
                             query=query_text,
                             type='cross_fields',
-                            fields=['title^7', 'description^4', 'organization_name^4'],
+                            fields=['id^7', 'title^7', 'description^4', 'organization_name^4'],
                             operator="and")]),
                         functions=reuses_score_functions
                     ),
@@ -385,7 +385,7 @@ class ElasticClient:
             search = search.query('bool', should=[
                     query.Q(
                         'function_score',
-                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['title^15', 'description^8', 'organization_name^8'])]),
+                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['id^15', 'title^15', 'description^8', 'organization_name^8'])]),
                         functions=dataservices_score_functions
                     ),
                     query.Q(
@@ -393,7 +393,7 @@ class ElasticClient:
                         query=query.Bool(should=[query.MultiMatch(
                             query=query_text,
                             type='cross_fields',
-                            fields=['title^7', 'description^4', 'organization_name^4'],
+                            fields=['id^7', 'title^7', 'description^4', 'organization_name^4'],
                             operator="and")]),
                         functions=dataservices_score_functions
                     ),

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -142,6 +142,8 @@ class SearchableDataset(IndexDocument):
     reuses = Float()
     featured = Integer()
     resources_count = Integer()
+    resources_ids = Keyword(multi=True)
+    resources_titles = Text(analyzer=dgv_analyzer)
     concat_title_org = Text(analyzer=dgv_analyzer)
     temporal_coverage_start = Date()
     temporal_coverage_end = Date()
@@ -282,7 +284,11 @@ class ElasticClient:
                 should=[
                     query.Q(
                         'function_score',
-                        query=query.Bool(should=[query.MultiMatch(query=query_text, type='phrase', fields=['id^15', 'title^15', 'acronym^15', 'description^8', 'organization_name^8'])]),
+                        query=query.Bool(should=[query.MultiMatch(
+                            query=query_text,
+                            type='phrase',
+                            fields=['id^15', 'title^15', 'acronym^15', 'description^8', 'organization_name^8', 'resources_ids^8', 'resources_titles^5']
+                        )]),
                         functions=datasets_score_functions
                     ),
                     query.Q(
@@ -295,7 +301,7 @@ class ElasticClient:
                         query=query.Bool(should=[query.MultiMatch(
                             query=query_text,
                             type='cross_fields',
-                            fields=['id^7', 'title^7', 'acronym^7', 'description^4', 'organization_name^4'],
+                            fields=['id^7', 'title^7', 'acronym^7', 'description^4', 'organization_name^4', 'resources_ids^4', 'resources_titles^2'],
                             operator="and")]),
                         functions=datasets_score_functions
                     ),

--- a/udata_search_service/presentation/api.py
+++ b/udata_search_service/presentation/api.py
@@ -163,6 +163,7 @@ class DatasetToIndex(BaseModel):
     followers: int
     reuses: int
     resources_count: Optional[int] = 0
+    resources: Optional[list] = None
     featured: Optional[int] = 0
     format: Optional[list] = []
     schema_: Optional[list] = Field([], alias="schema")


### PR DESCRIPTION
Part of https://github.com/datagouv/data.gouv.fr/issues/1593
Requires https://github.com/opendatateam/udata/pull/3408

It allows to use the resources titles and ids in the search.

Example usage:
http://dev.local:3000/datasets/?q=bal
http://dev.local:3000/datasets/?q=Sirene+%3A+Fichier+StockUniteLegale+du+01+Juillet+2025
http://dev.local:3000/datasets/?q=9e1ddf3e-8bcc-41c3-a3c1-60ddfe85504f
http://dev.local:3000/datasets/?q=BassinVersantTopographique_FXX_Topage2023