### PR TITLE
fix(topics): sort by name

### DIFF
--- a/tests/test_search_client.py
+++ b/tests/test_search_client.py
@@ -1,7 +1,7 @@
 import datetime
 import time
 
-from udata_search_service.domain.factories import DataserviceFactory, DatasetFactory, OrganizationFactory, ReuseFactory
+from udata_search_service.domain.factories import DataserviceFactory, DatasetFactory, OrganizationFactory, ReuseFactory, TopicFactory
 
 ext_word_list = ['abc', 'def', 'hij', 'klm', 'nop', 'qrs', 'tuv']
 
@@ -527,4 +527,54 @@ def test_search_dataset_by_resource_title_and_id(app, client, search_client, fak
 
     results_number, res, _ = search_client.query_datasets(str(dataset.resources_titles[0]), 0, 20, {})
     assert results_number == 1
+
+
+def test_topic_sort_by_name(app, client, search_client, faker):
+    search_client.index_topic(TopicFactory(name='aaa topic'))
+    search_client.index_topic(TopicFactory(name='zzz topic'))
+
+    # Without this, ElasticSearch does not seem to have the time to index.
+    time.sleep(2)
+
+    _, res, _ = search_client.query_topics(None, 0, 20, {}, sort='name')
+    assert res[0]['name'] == 'aaa topic'
+    assert res[1]['name'] == 'zzz topic'
+
+    _, res, _ = search_client.query_topics(None, 0, 20, {}, sort='-name')
+    assert res[0]['name'] == 'zzz topic'
+    assert res[1]['name'] == 'aaa topic'
+
+
+def test_topic_sort_by_created(app, client, search_client, faker):
+    old = datetime.datetime(2020, 1, 1)
+    new = datetime.datetime(2024, 1, 1)
+    search_client.index_topic(TopicFactory(name='old topic', created_at=old))
+    search_client.index_topic(TopicFactory(name='new topic', created_at=new))
+
+    time.sleep(2)
+
+    _, res, _ = search_client.query_topics(None, 0, 20, {}, sort='created_at')
+    assert res[0]['name'] == 'old topic'
+    assert res[1]['name'] == 'new topic'
+
+    _, res, _ = search_client.query_topics(None, 0, 20, {}, sort='-created_at')
+    assert res[0]['name'] == 'new topic'
+    assert res[1]['name'] == 'old topic'
+
+
+def test_topic_sort_by_last_modified(app, client, search_client, faker):
+    old = datetime.datetime(2020, 1, 1)
+    new = datetime.datetime(2024, 1, 1)
+    search_client.index_topic(TopicFactory(name='old topic', last_modified=old))
+    search_client.index_topic(TopicFactory(name='new topic', last_modified=new))
+
+    time.sleep(2)
+
+    _, res, _ = search_client.query_topics(None, 0, 20, {}, sort='last_modified')
+    assert res[0]['name'] == 'old topic'
+    assert res[1]['name'] == 'new topic'
+
+    _, res, _ = search_client.query_topics(None, 0, 20, {}, sort='-last_modified')
+    assert res[0]['name'] == 'new topic'
+    assert res[1]['name'] == 'old topic'
 

--- a/udata_search_service/domain/factories.py
+++ b/udata_search_service/domain/factories.py
@@ -1,7 +1,7 @@
 import datetime
 import factory
 
-from udata_search_service.domain.entities import Dataservice, Dataset, Organization, Reuse
+from udata_search_service.domain.entities import Dataservice, Dataset, Organization, Reuse, Topic
 
 
 class DatasetFactory(factory.Factory):
@@ -95,3 +95,15 @@ class DataserviceFactory(factory.Factory):
     organization = factory.Faker('md5')
     organization_name = factory.Faker('company')
     owner = factory.Faker('md5')
+
+
+class TopicFactory(factory.Factory):
+    class Meta:
+        model = Topic
+
+    id = factory.Faker('md5')
+    name = factory.Faker('sentence')
+    description = factory.Faker('text')
+    created_at = factory.LazyFunction(datetime.datetime.utcnow)
+    last_modified = factory.LazyFunction(datetime.datetime.utcnow)
+    tags = []

--- a/udata_search_service/infrastructure/migrate.py
+++ b/udata_search_service/infrastructure/migrate.py
@@ -14,6 +14,7 @@ ALL_INDICES = [
     'reuse',
     'organization',
     'dataservice',
+    'topic',
 ]
 
 

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -92,7 +92,7 @@ class SearchableDataservice(IndexDocument):
 
 
 class SearchableTopic(IndexDocument):
-    name = Text(analyzer=dgv_analyzer)
+    name = Text(analyzer=dgv_analyzer, fields={'keyword': Keyword()})
     description = Text(analyzer=dgv_analyzer)
     tags = Keyword(multi=True)
     featured = Integer()
@@ -479,6 +479,10 @@ class ElasticClient:
                 sort_field = 'last_modified'
             elif sort == '-last_update':
                 sort_field = '-last_modified'
+            elif sort == 'name':
+                sort_field = 'name.keyword'
+            elif sort == '-name':
+                sort_field = '-name.keyword'
             search = search.sort(sort_field, {'_score': {'order': 'desc'}})
 
         search = search[offset:(offset + page_size)]


### PR DESCRIPTION
Fix this error when sorting Topics by name:

```
INFO:elastic_transport.transport:POST http://192.168.0.123:9200/demo-topic/_search [status:400 duration:0.001s]
ERROR:udata_search_service.app:Exception on /api/1/topics/ [GET]
Traceback (most recent call last):
  File "/srv/demo-search/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/dependency_injector/wiring.py", line 1089, in _patched
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/udata_search_service/presentation/api.py", line 781, in topics_search
    results, results_number, total_pages, facets = topic_service.search(request_args.dict())
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/udata_search_service/infrastructure/services.py", line 261, in search
    results_number, search_results, facets = self.search_client.query_topics(search_text, offset, page_size, filters, sort)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/udata_search_service/infrastructure/search_clients.py", line 486, in query_topics
    response = search.execute()
               ^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/elasticsearch/dsl/_sync/search.py", line 97, in execute
    es.search(index=self._index, body=self.to_dict(), **self._params)
  File "/srv/demo-search/lib/python3.11/site-packages/elasticsearch/_sync/client/utils.py", line 452, in wrapped
    return api(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/elasticsearch/_sync/client/__init__.py", line 5113, in search
    return self.perform_request(  # type: ignore[return-value]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/elasticsearch/_sync/client/_base.py", line 271, in perform_request
    response = self._perform_request(
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/demo-search/lib/python3.11/site-packages/elasticsearch/_sync/client/_base.py", line 351, in _perform_request
    raise HTTP_EXCEPTIONS.get(meta.status, ApiError)(
elasticsearch.BadRequestError: BadRequestError(400, 'search_phase_execution_exception', 'Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [name] in order to load field data by uninverting the inverted index. Note that this can use significant memory.', Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [name] in order to load field data by uninverting the inverted index. Note that this can use significant memory.)
```